### PR TITLE
Solved: PG_재구매가 일어난 상품과 회원 리스트 구하기 홍지우

### DIFF
--- a/SQL고득점Kit/SELECT/지우/재구매가 일어난 상품과 회원 리스트 구하기.sql
+++ b/SQL고득점Kit/SELECT/지우/재구매가 일어난 상품과 회원 리스트 구하기.sql
@@ -1,0 +1,5 @@
+SELECT user_id, product_id
+FROM online_sale
+GROUP BY user_id, product_id
+HAVING COUNT(*) >= 2
+ORDER BY user_id, product_id DESC


### PR DESCRIPTION
- 처음에 자기조인으로 풀까 했는데 a.purchase_date < b.purchase_date 이렇게 조건해서 풀면 중복되는 결과를 너무 많이 만든 후 쿼리로 다듬는 것 같아서 다시 생각함
- 쌍(회원ID, 구매ID) 이거에 대한 '묶음' 개념을 떠올림 -> GROUP BY..!!
- HAVING <- group by 사용한 경우에는 WHERE 대신 이거 써야징~~
- HAVING COUNT(*) >= 2 <- 그룹쌍 2개 이상인거!