### PR TITLE
Solved: PG_오프라인/온라인 판매 데이터 통합하기 홍지우

### DIFF
--- a/SQL고득점Kit/SELECT/지우/오프라인/온라인 판매 데이터 통합하기.sql
+++ b/SQL고득점Kit/SELECT/지우/오프라인/온라인 판매 데이터 통합하기.sql
@@ -1,0 +1,8 @@
+(SELECT date_format(sales_date,"%Y-%m-%d") as sales_date, product_id, user_id, sales_amount 
+ FROM online_sale
+ WHERE date_format(sales_date, "%Y-%m") = '2022-03')
+UNION
+(SELECT date_format(sales_date,"%Y-%m-%d") as sales_date, product_id, NULL as user_id, sales_amount 
+ FROM offline_sale
+ WHERE date_format(sales_date, "%Y-%m") = '2022-03')
+ORDER BY sales_date, product_id, user_id;


### PR DESCRIPTION
- 온라인, 오프라인 두 테이블을 합쳐 보여줘야 한다 -> UNION (어차피 중복 없음. 다른 테이블이니까)
- 오프 테이블에는 User_id가 없다. 이걸 NULL로 채워서 보여줘야 한다. -> `NULL as user_id` (user_id 칸에 null 값을 넣는다)
    - "NULL" as user_id <- 이건 안됨. ㄹㅇ null을 넣어야 하기 때문에 문자열과 다르다.
- ORDER BY는 Union 하고 최종적으로 하나만 