### PR TITLE
Solved: PG_상품 별 오프라인 매출 구하기 홍지우

### DIFF
--- a/SQL고득점Kit/JOIN/지우/상품 별 오프라인 매출 구하기.sql
+++ b/SQL고득점Kit/JOIN/지우/상품 별 오프라인 매출 구하기.sql
@@ -1,0 +1,8 @@
+# 상품코드 별 매출액(판매가*판매량) 합계
+SELECT p.product_code, (s.sum_amount * p.price) as sales
+FROM product as p
+    JOIN (SELECT *, SUM(sales_amount) as sum_amount 
+          FROM offline_sale GROUP BY product_id) as s
+    ON p.product_id = s.product_id
+GROUP BY product_code
+ORDER BY 2 DESC, 1


### PR DESCRIPTION
PR 왜 안 올렸지 2..

### 배운 점
- 미리 판매량 SUM 해두고 sum 한 amount랑 price랑 곱해서 풀었다
- 여기서는 JOIN한 두 테이블이 product_id로 이미 다 다르다는게 가정된 상태에서 sum() 을 했으니 고유한 애들이 잘 더해져서 2번줄 SELECT 에서 SUM이 필요 없었다.
    - 근데 한 sum에 여러 개의 id가 존재할 수 있는 경우에는 이렇게 쓰면 틀리게 됨 
    - 이런 부분 유의하자

---

```
WITH filteredBS AS (
    SELECT book_id, SUM(SALES) as sum_sales
    FROM BOOK_SALES
    WHERE YEAR(sales_date) = '2022' AND MONTH(sales_date) = '01'
    GROUP BY book_id
)

# 저자ID별, 카테고리별 '매출액(판매량 * 판매가)'
SELECT a.author_id, a.author_name, b.category, 
        SUM(b.price * bs.sum_sales) as total_sales # 여기서 얜 SUM()이 없으면 틀린 답이었음!!
FROM BOOK as b
    JOIN AUTHOR as a ON b.author_id = a.author_id
    JOIN filteredBS as bs ON b.book_id = bs.book_id
GROUP BY 1,2,3 
ORDER BY 1,3 DESC;

````

book_id는 GROUP BY에 없음!

그런데 b.price * bs.sum_sales는 book 단위로 계산된 매출

author_id, category 단위로 묶으면서 book_id가 여러 개일 수 있음
→ 이럴 땐 반드시 SUM()으로 총 매출을 구해야 정확해