### PR TITLE
Solved: PG_진료과별 총 예약 횟수 출력하기 김나영

### DIFF
--- a/SQL고득점Kit/GROUP BY/나영/진료과별 총 예약 횟수 출력하기.sql
+++ b/SQL고득점Kit/GROUP BY/나영/진료과별 총 예약 횟수 출력하기.sql
@@ -1,0 +1,12 @@
+SELECT 
+    MCDP_CD AS 진료과코드,
+    COUNT(MCDP_CD) AS 5월예약건수
+FROM 
+    APPOINTMENT
+WHERE
+    DATE_FORMAT(APNT_YMD, "%Y-%m") = '2022-05'
+GROUP BY 
+    MCDP_CD
+ORDER BY
+    5월예약건수, 
+    진료과코드


### PR DESCRIPTION
### 배운점
- 한국어로 컬럼명을 써야 하는 신기한 문제,,!
- 컬럼명을 쓸 때는 한국어라도 따옴표는 쓰지 않는다
- 만약 ORDER BY에서 따옴표를 쓰면 ㄹㅇ 그 문자열로 생각하고 받는다,, 주의!
- ORACLE의 경우 컬럼명은 큰따옴표, 문자열은 작은따옴표로 구별해서 받는다고 합니당

```
# ORACLE VER
SELECT 
    MCDP_CD AS "진료과코드",
    COUNT(MCDP_CD) AS "5월예약건수"
FROM 
    APPOINTMENT
WHERE
    TO_CHAR(APNT_YMD, 'YYYY-MM') = '2022-05'
GROUP BY 
    MCDP_CD
ORDER BY
    "5월예약건수", 
    "진료과코드"
```